### PR TITLE
fixed bug when new collection doesn't have a floor price yet: NoSuchM…

### DIFF
--- a/lib/pojo/collection_object.dart
+++ b/lib/pojo/collection_object.dart
@@ -336,7 +336,7 @@ class Stats {
     averagePrice = json['average_price'];
     numReports = json['num_reports'];
     marketCap = json['market_cap'];
-    floorPrice = json['floor_price'].toDouble();
+    floorPrice = json['floor_price']?.toDouble();
   }
 
   Map<String, dynamic> toJson() {


### PR DESCRIPTION
`[log] NoSuchMethodError: The method 'toDouble' was called on null.
Receiver: null
Tried calling: toDouble()
      #0      Object.noSuchMethod (dart:core-patch/object_patch.dart:38:5)
      #1      new Stats.fromJson (package:opensea_dart/pojo/collection_object.dart:339:38)
      #2      new Collection.fromJson (package:opensea_dart/pojo/collection_object.dart:159:43)
      #3      new CollectionObject.fromJson (package:opensea_dart/pojo/collection_object.dart:45:22)
      #4      OpenSea.getCollection (package:opensea_dart/opensea_dart.dart:308:29)
`